### PR TITLE
Add `--cookie-file/-C <path>` to persist randomly generated login credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Add `--login-file/-U <path>` to persist randomly generated login credentials to `<path>`
-  (similar to the "cookie file" feature in bitcoind).
+- Add `--cookie-file/-C <path>` to persist randomly generated login credentials to `<path>`
+  (similar to the cookie file feature in bitcoind).
 
 - Add `--public-url` CLI option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `--login-file/-U <path>` to persist randomly generated login credentials to `<path>`
+  (similar to the "cookie file" feature in bitcoind).
+
 - Add `--public-url` CLI option
 
 ## 0.2.0 - 2018-12-11

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ spark-wallet # defaults: --ln-path ~/.lightning --port 9737
 Or simply `$ npx spark-wallet`, which will install and start Spark (with the default args) in one go.
 
 Spark will generate and print a random username and password that'll be used to login into the wallet.
-To persist/load the generated credentials, set `--login-file <path>`.
+To persist/load the generated credentials, set `--cookie-file <path>`.
 To specify your own login credentials, set `--login [user]:[pass]` or the `LOGIN` environment variable.
 
 To access the wallet, open `http://localhost:9737/` in your browser and login with the username/password.
@@ -264,7 +264,7 @@ $ spark-wallet --help
     -p, --port <port>        http(s) server port [default: 9737]
     -i, --host <host>        http(s) server listen address [default: localhost]
     -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
-    -U, --login-file <path>  persist randomly generated login to <path> [default: dont persist]
+    -C, --cookie-file <path> persist generated login credentials to <path> or load them [default: none]
 
     --force-tls              enable TLS even when binding on localhost [default: enable for non-localhost only]
     --no-tls                 disable TLS for non-localhost hosts [default: false]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ spark-wallet # defaults: --ln-path ~/.lightning --port 9737
 Or simply `$ npx spark-wallet`, which will install and start Spark (with the default args) in one go.
 
 Spark will generate and print a random username and password that'll be used to login into the wallet.
+To persist/load the generated credentials, set `--login-file <path>`.
 To specify your own login credentials, set `--login [user]:[pass]` or the `LOGIN` environment variable.
 
 To access the wallet, open `http://localhost:9737/` in your browser and login with the username/password.
@@ -260,9 +261,10 @@ $ spark-wallet --help
 
   Options
     -l, --ln-path <path>     path to c-lightning data directory [default: ~/.lightning]
-    -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
     -p, --port <port>        http(s) server port [default: 9737]
     -i, --host <host>        http(s) server listen address [default: localhost]
+    -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
+    -U, --login-file <path>  persist randomly generated login to <path> [default: dont persist]
 
     --force-tls              enable TLS even when binding on localhost [default: enable for non-localhost only]
     --no-tls                 disable TLS for non-localhost hosts [default: false]

--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@
   // Middlewares
   app.use(require('morgan')('dev'))
   app.use(require('body-parser').json())
-  app.use(require('./auth')(app, process.env.LOGIN_FILE, process.env.LOGIN, process.env.ACCESS_KEY))
+  app.use(require('./auth')(app, process.env.COOKIE_FILE, process.env.LOGIN, process.env.ACCESS_KEY))
   app.use(require('compression')())
   app.use(require('helmet')({ contentSecurityPolicy: { directives: {
     defaultSrc: [ "'self'" ]

--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@
   // Middlewares
   app.use(require('morgan')('dev'))
   app.use(require('body-parser').json())
-  app.use(require('./auth')(app, process.env.LOGIN, process.env.ACCESS_KEY))
+  app.use(require('./auth')(app, process.env.LOGIN_FILE, process.env.LOGIN, process.env.ACCESS_KEY))
   app.use(require('compression')())
   app.use(require('helmet')({ contentSecurityPolicy: { directives: {
     defaultSrc: [ "'self'" ]

--- a/src/auth.js
+++ b/src/auth.js
@@ -10,16 +10,16 @@ const cookieAge = 2592000000 // 1 month
 
 const hmacStr = (key, data) => createHmac('sha256', key).update(data).digest('base64').replace(/\W+/g, '')
 
-module.exports = (app, loginFile, login, _accessKey) => {
-  if (loginFile && (login || _accessKey)) throw new Error('--login-file cannot be used with --login or --access-key')
+module.exports = (app, cookieFile, login, _accessKey) => {
+  if (cookieFile && (login || _accessKey)) throw new Error('--cookie-file cannot be used with --login or --access-key')
 
   let username, password
 
-  const hasFile = loginFile && fs.existsSync(loginFile)
+  const hasFile = cookieFile && fs.existsSync(cookieFile)
   if (hasFile) {
-    console.log(`Loading login credentials from ${loginFile}`)
-    ;[ username, password, _accessKey ] = fs.readFileSync(loginFile).toString('utf-8').trim().split(':')
-    assert(password, `Invalid login file at ${loginFile}, expecting "username:pwd[:access-key]"`)
+    console.log(`Loading login credentials from ${cookieFile}`)
+    ;[ username, password, _accessKey ] = fs.readFileSync(cookieFile).toString('utf-8').trim().split(':')
+    assert(password, `Invalid login file at ${cookieFile}, expecting "username:pwd[:access-key]"`)
   } else if (login) { // provided via --login (or LOGIN)
     ;[ username, password ] = login.split(':', 2)
     assert(password, `Invalid login format, expecting "username:pwd"`)
@@ -36,9 +36,9 @@ module.exports = (app, loginFile, login, _accessKey) => {
       , cookieKey   = hmacStr(accessKey, 'cookie-key')
       , cookieOpt   = { signed: true, httpOnly: true, sameSite: true, secure: app.enabled('tls'), maxAge: cookieAge }
 
-  if (loginFile && !hasFile) {
-    console.log(`Writing login credentials to ${loginFile}`)
-    fs.writeFileSync(loginFile, [ username, password, accessKey ].join(':'))
+  if (cookieFile && !hasFile) {
+    console.log(`Writing login credentials to ${cookieFile}`)
+    fs.writeFileSync(cookieFile, [ username, password, accessKey ].join(':'))
   }
 
   Object.assign(app.settings, { manifestKey, accessKey })

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,9 +6,10 @@ const args = require('meow')(`
 
     Options
       -l, --ln-path <path>     path to c-lightning data directory [default: ~/.lightning]
-      -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
       -p, --port <port>        http(s) server port [default: 9737]
       -i, --host <host>        http(s) server listen address [default: localhost]
+      -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
+      -U, --login-file <path>  persist randomly generated login to <path> [default: dont persist]
 
       --force-tls              enable TLS even when binding on localhost [default: enable for non-localhost only]
       --no-tls                 disable TLS for non-localhost hosts [default: false]
@@ -42,7 +43,7 @@ const args = require('meow')(`
     All options may also be specified as environment variables:
       $ LN_PATH=/data/lightning PORT=8070 NO_TLS=1 spark-wallet
 
-`, { flags: { lnPath: {alias:'l'}, login: {alias:'u'}
+`, { flags: { lnPath: {alias:'l'}, login: {alias:'u'}, loginFile: {alias:'U'}
             , port: {alias:'p'}, host: {alias:'i'}
             , leNoverify: {type:'boolean'}, leDebug: {type:'boolean'}
             , printKey: {type:'boolean', alias:'k'}, printQr: {type:'boolean', alias:'q'}, pairingQr: {type:'boolean', alias:'Q'}

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ const args = require('meow')(`
       -p, --port <port>        http(s) server port [default: 9737]
       -i, --host <host>        http(s) server listen address [default: localhost]
       -u, --login <userpwd>    http basic auth login, "username:password" format [default: generate random]
-      -U, --login-file <path>  persist randomly generated login to <path> [default: dont persist]
+      -C, --cookie-file <path> persist generated login credentials to <path> or load them [default: none]
 
       --force-tls              enable TLS even when binding on localhost [default: enable for non-localhost only]
       --no-tls                 disable TLS for non-localhost hosts [default: false]
@@ -43,7 +43,7 @@ const args = require('meow')(`
     All options may also be specified as environment variables:
       $ LN_PATH=/data/lightning PORT=8070 NO_TLS=1 spark-wallet
 
-`, { flags: { lnPath: {alias:'l'}, login: {alias:'u'}, loginFile: {alias:'U'}
+`, { flags: { lnPath: {alias:'l'}, login: {alias:'u'}, cookieFile: {alias:'C'}
             , port: {alias:'p'}, host: {alias:'i'}
             , leNoverify: {type:'boolean'}, leDebug: {type:'boolean'}
             , printKey: {type:'boolean', alias:'k'}, printQr: {type:'boolean', alias:'q'}, pairingQr: {type:'boolean', alias:'Q'}


### PR DESCRIPTION
Reads login credentials from `<path>` if it exists, otherwise generates random credentials and saves them to it. Similar to bitcoind's cookie file functionality. The data is saved in a `username:password:access-key` format.

Requested by @NicolasDorier for easier integration in a docker-compose setup.