### PR TITLE
build.sh: Fix chmod

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ cp src/transport/granax-dep/{package,npm-shrinkwrap}.json dist/transport/granax-
 (cd client && DEST=../dist/www npm run dist)
 
 # Remove sources of non-determinism
-chmod -R 755 dist package.json npm-shrinkwrap.json README.md CHANGELOG.md LICENSE
+chmod -R a+rX dist package.json npm-shrinkwrap.json README.md CHANGELOG.md LICENSE
 TZ=UTC touch -t "1711081658.41" package.json npm-shrinkwrap.json README.md CHANGELOG.md LICENSE
 TZ=UTC find dist -exec touch -t "1711081658.41" {} \;
 # this is done automatically since npm v5.7.1, but the latest stable 5.7.x and 5.8.x are currently buggy (https://github.com/npm/npm/issues/19989)


### PR DESCRIPTION
This simple patch just fixes `chmod` which was adding executable mode bit on files which are just text files.

Using `a+X` is POSIX, so should be an all unices, macOS, etc. See http://pubs.opengroup.org/onlinepubs/9699919799/utilities/chmod.html