### PR TITLE
Bug fixes

### DIFF
--- a/doc/dev-regtest-env.md
+++ b/doc/dev-regtest-env.md
@@ -10,10 +10,10 @@ $ lightningd --network regtest --lightning-dir /tmp/spark-env/ln1 --bitcoin-data
 $ lightningd --network regtest --lightning-dir /tmp/spark-env/ln2 --bitcoin-datadir /tmp/spark-env/btc --addr 127.0.0.1:9601
 
 $ alias btc='bitcoin-cli --regtest --datadir=/tmp/spark-env/btc' \
-        ln1='lightning-cli --lightning-dir /tmp/spark-env/ln1' \
-        ln2='lightning-cli --lightning-dir /tmp/spark-env/ln2'
+        ln1='lightning-cli --network regtest --lightning-dir /tmp/spark-env/ln1' \
+        ln2='lightning-cli --network regtest --lightning-dir /tmp/spark-env/ln2'
 
-$ btc generate 101 && btc sendtoaddress $(ln1 newaddr | jq -r .address) 5 && btc generate 1
+$ btc generatetoaddress 101 $(ln1 newaddr | jq -r .address)
 
 # wait for onchain funds to show up on `ln1 listfunds` (updated every 30s)
 


### PR DESCRIPTION
- Use `generatetoaddress` instead deprecated `generate` RPC call.
- Add `--network regtest` flag to `lightning-cli` alias, to work properly.