### PR TITLE
feat: exchange rate provider bitstamp_eur

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ $ spark-wallet --help
     -C, --cookie-file <path> persist generated login credentials to <path> or load them [default: ~/.spark-wallet/cookie]
     --no-cookie-file         disable cookie file [default: false]
 
-    --rate-provider <name>   exchange rate provider, one of "bitstamp" or "wasabi" (requires tor) [default: bitstamp]
+    --rate-provider <name>   exchange rate provider: "bitstamp", "bitstamp_eur" or "wasabi" (requires tor) [default: bitstamp]
     --no-rates               disable exchange rate lookup [default: false]
     --proxy <uri>            set a proxy for looking up rates, e.g. socks5h://127.0.0.1:9050 [default: none]
 

--- a/src/exchange-rate.js
+++ b/src/exchange-rate.js
@@ -10,6 +10,11 @@ const rateProviders = {
   , parser: r => r.body.last
   }
 
+, bitstamp_eur: {
+    url: 'https://www.bitstamp.net/api/v2/ticker/btceur'
+  , parser: r => r.body.last
+  }
+
 , wasabi: {
     url: 'http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/api/v4/btc/Offchain/exchange-rates'
   , parser: r => r.body[0].rate


### PR DESCRIPTION
This simply adds a `bitstamp_eur` provider that can also be set as environment variable.

Update: this is only half of the work, as we also need to care the client code that renders '`$`' or '`usd`' when prices are shown.