### PR TITLE
fix: CI install recent openjdk-8 deb9u1 version

### DIFF
--- a/scripts/builder.Dockerfile
+++ b/scripts/builder.Dockerfile
@@ -29,7 +29,7 @@ ENV ANDROID_HOME=/root/sdktools
 ENV PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:/root/gradle-4.1/bin
 WORKDIR /root
 # Java 8 (OpenJDK)
-RUN apt-get install -y --no-install-recommends openjdk-8-jdk-headless=8u265-b01-0+deb9u1
+RUN apt-get install -y --no-install-recommends openjdk-8-jdk-headless=8u272-b10-0+deb9u1
 
 # Android SKD tools
 RUN wget -q -O sdktools.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \


### PR DESCRIPTION
Currently CI fails with:
```
E: Version '8u265-b01-0+deb9u1' for 'openjdk-8-jdk-headless' was not found
The command '/bin/sh -c apt-get install -y --no-install-recommends openjdk-8-jdk-headless=8u265-b01-0+deb9u1' returned a non-zero code: 100
```

This patch updates this artifact to recent version: 8u272-b10-0+deb9u1
Alternatively we could remove the specific opendjdk8 version and leave
this to the debian maintainers to give us a recent fixed one.

Addresses broken CI build of https://github.com/shesek/spark-wallet/pull/162