### PR TITLE
make client module build independently

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -13,7 +13,7 @@ export VERSION=`node -p 'require("../package").version'`
 rm -rf $DEST/*
 mkdir -p $DEST $DEST/lib $DEST/fonts $DEST/swatch
 
-[[ -d node_modules ]] || NODE_ENV=development npm install
+[[ -d node_modules ]] || NODE_ENV=development npm install --unsafe-perm
 
 # Static assets
 cp -r www/* $DEST/

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -996,6 +996,30 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.11.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/cli": "^7.11.5",
     "@babel/core": "^7.11.5",
+    "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.11.5",
     "babelify": "^10.0.0",
     "browserify": "^16.5.2",


### PR DESCRIPTION
in clean environment:

```
cd spark-wallet/client && PATH=$PATH:./node_modules/.bin/ ./build.sh
+ shopt -s extglob
+ : dist
+ : production
+ : web
+ export BUILD_TARGET
+ export NODE_ENV
++ node -p 'require("../package").version'
+ export VERSION=0.2.16
+ VERSION=0.2.16
+ rm -rf 'dist/*'
+ mkdir -p dist dist/lib dist/fonts dist/swatch
+ [[ -d node_modules ]]
+ cp -r www/favicon.ico www/manifest www/notification.png dist/
+ cp -r 'fonts/node_modules/typeface-*' dist/fonts/
cp: cannot stat 'fonts/node_modules/typeface-*': No such file or directory

```

this fixes that.

CI failing addressed in #170 